### PR TITLE
fix(#7): default bot channel id

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 DISCORD_TOKEN=user_provided
+BOT_CHANNLE_ID=0

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CTF 用の discord bot
 Install Link を None にする必要があるかもしれません(要出典)
 ### Bot
 `cp .env.example .env` とし、`.env` 内の `user_provided` を token の実際の文字列で置き換えてください。
+ついでに `BOT_CHANNEL_ID` を bot の自動メッセージを流すチャンネル ID にセットしておくと良いと思います。
 このファイルは絶対に commit に含めないでください。
 このリポジトリは現状 private ではあるし `.gitignore` にも含めていますが、個人でも気をつけてください。
 


### PR DESCRIPTION
close #7

bot channel id のデフォルト値として 0 を `.env.example` に入れました。