### PR TITLE
Feat/discord message ux

### DIFF
--- a/src/bot/features/alpacahack/cog.py
+++ b/src/bot/features/alpacahack/cog.py
@@ -9,7 +9,6 @@ from discord.ext import commands, tasks
 
 from ...cogs._runtime import get_runtime
 from ...utils.helpers import (
-    format_code_block,
     logger,
     send_interaction_message,
     send_message_safely,
@@ -74,11 +73,11 @@ class Alpacahack(
         *,
         empty_message: str,
         max_items: int,
+        max_length: int = 1024,
     ) -> str:
         if not entries:
             return empty_message
 
-        max_length = 1024
         lines: list[str] = []
         for entry in entries[:max_items]:
             if len("\n".join([*lines, entry])) > max_length:
@@ -93,7 +92,7 @@ class Alpacahack(
 
         omitted = len(entries) - len(lines)
         if omitted > 0:
-            overflow = f"... and {omitted} more"
+            overflow = f"... 他 {omitted} 件"
             if len("\n".join([*lines, overflow])) <= max_length:
                 lines.append(overflow)
 
@@ -125,18 +124,35 @@ class Alpacahack(
         )
 
     @staticmethod
+    def _format_username_entry(username: str) -> str:
+        escaped = discord.utils.escape_markdown(username, as_needed=True)
+        return f"- {escaped}"
+
+    @classmethod
+    def _format_username_list(cls, usernames: list[str]) -> str:
+        header = "登録済みAlpacaHackユーザー"
+        available_length = 1900 - len(header) - 1
+        body = cls._format_lines(
+            [cls._format_username_entry(username) for username in usernames],
+            empty_message="誰も登録されていません。",
+            max_items=len(usernames),
+            max_length=available_length,
+        )
+        return f"{header}\n{body}"
+
+    @staticmethod
     def _to_user_message(result: UserMutationResult) -> str:
         if result.status == UserMutationStatus.INVALID_NAME:
             return "ユーザー名が空です。"
         if result.status == UserMutationStatus.CREATED:
-            return f"User '{result.normalized_name}' added."
+            return f"`{result.normalized_name}` を登録しました。"
         if result.status == UserMutationStatus.ALREADY_EXISTS:
-            return f"User '{result.normalized_name}' is already registered."
+            return f"`{result.normalized_name}` は既に登録されています。"
         if result.status == UserMutationStatus.DELETED:
-            return f"Deleted user: {result.normalized_name}"
+            return f"`{result.normalized_name}` の登録を削除しました。"
         if result.status == UserMutationStatus.NOT_FOUND:
-            return f"No user: {result.normalized_name}"
-        return "Unknown result."
+            return f"`{result.normalized_name}` は登録されていません。"
+        return "不明な結果です。"
 
     def _build_weekly_summary_embed(self, summary: WeeklySolveSummary) -> discord.Embed:
         total_solves = sum(len(items) for items in summary.weekly_solves.values())
@@ -192,9 +208,7 @@ class Alpacahack(
         if len(sorted_rows) > max_user_fields:
             embed.set_footer(
                 text=(
-                    "+ "
-                    f"{len(sorted_rows) - max_user_fields} users are omitted due to "
-                    "Discord limits"
+                    f"Discord上限のため他 {len(sorted_rows) - max_user_fields} 人を省略"
                 )
             )
 
@@ -213,7 +227,7 @@ class Alpacahack(
         if summary.total_users == 0:
             if notify_if_no_users:
                 await send_message_safely(
-                    target_channel, content="誰も登録されていません"
+                    target_channel, content="誰も登録されていません。"
                 )
             return
 
@@ -234,8 +248,8 @@ class Alpacahack(
             if notify_if_no_users:
                 await send_interaction_message(
                     interaction,
-                    "誰も登録されていません",
-                    ephemeral=False,
+                    "誰も登録されていません。",
+                    ephemeral=True,
                 )
             return
 
@@ -275,7 +289,7 @@ class Alpacahack(
         await send_interaction_message(
             interaction,
             self._to_user_message(result),
-            ephemeral=False,
+            ephemeral=True,
         )
 
     @app_commands.command(
@@ -288,7 +302,7 @@ class Alpacahack(
         await send_interaction_message(
             interaction,
             self._to_user_message(result),
-            ephemeral=False,
+            ephemeral=True,
         )
 
     @app_commands.command(
@@ -300,16 +314,15 @@ class Alpacahack(
         if not usernames:
             await send_interaction_message(
                 interaction,
-                "誰も登録されていません",
-                ephemeral=False,
+                "誰も登録されていません。",
+                ephemeral=True,
             )
             return
 
-        user_list = "\n".join(usernames)
         await send_interaction_message(
             interaction,
-            format_code_block(user_list),
-            ephemeral=False,
+            self._format_username_list(usernames),
+            ephemeral=True,
         )
 
     @app_commands.command(

--- a/src/bot/features/ctf_roles/cog.py
+++ b/src/bot/features/ctf_roles/cog.py
@@ -18,6 +18,7 @@ from .archive_flow import archive_campaign
 from .models import (
     INPUT_DATETIME_PLACEHOLDER,
     CampaignDraft,
+    CampaignStatus,
     CloseCampaignReport,
     CTFRoleCampaign,
 )
@@ -29,6 +30,10 @@ LIST_LIMIT = 20
 STATUS_ACTIVE = "active"
 STATUS_CLOSED = "closed"
 STATUS_ALL = "all"
+STATUS_LABELS = {
+    CampaignStatus.ACTIVE: "募集中",
+    CampaignStatus.CLOSED: "終了済み",
+}
 CLOSED_HEADER = "🔒 **この募集は終了しました。**"
 CTF_CATEGORY_NAME = "ctf"
 ARCHIVE_CATEGORY_NAME = "archive"
@@ -667,7 +672,7 @@ class CTFRoleCampaigns(
             key=lambda member: (member.display_name.lower(), member.id),
         )
         member_chunks = self._split_member_mentions(members)
-        archive_text = self.usecase.format_unix_datetime(archive_at_unix)
+        archive_text = self.usecase.format_unix_datetime_with_relative(archive_at_unix)
         for index, member_chunk in enumerate(member_chunks, start=1):
             suffix = (
                 "" if len(member_chunks) == 1 else f" ({index}/{len(member_chunks)})"
@@ -722,11 +727,15 @@ class CTFRoleCampaigns(
         role: discord.Role,
         discussion_channel: discord.TextChannel,
     ) -> str:
-        start_text = self.usecase.format_unix_datetime(draft.start_at_unix)
+        start_text = self.usecase.format_unix_datetime_with_relative(
+            draft.start_at_unix
+        )
         if draft.end_at_unix is None:
             end_text = "常設(手動で /ctfteam close)"
         else:
-            end_text = self.usecase.format_unix_datetime(draft.end_at_unix)
+            end_text = self.usecase.format_unix_datetime_with_relative(
+                draft.end_at_unix
+            )
 
         return (
             f"📣 **{draft.ctf_name}** 参加者募集\n"
@@ -737,29 +746,101 @@ class CTFRoleCampaigns(
             "(終了時刻まで有効)。"
         )
 
-    def _format_campaign_line(self, campaign: CTFRoleCampaign) -> str:
-        start_text = self.usecase.format_unix_datetime(campaign.start_at_unix)
-        end_text = (
-            self.usecase.format_unix_datetime(campaign.end_at_unix)
-            if campaign.end_at_unix is not None
-            else "常設"
-        )
-        archive_text = (
-            self.usecase.format_unix_datetime(campaign.archive_at_unix)
-            if campaign.archive_at_unix is not None
-            else "-"
-        )
-        archived_text = (
-            self.usecase.format_unix_datetime(campaign.archived_at_unix)
-            if campaign.archived_at_unix is not None
-            else "-"
-        )
+    @staticmethod
+    def _build_campaign_jump_url(campaign: CTFRoleCampaign) -> str:
         return (
-            f"- {campaign.ctf_name} | status={campaign.status.value} | "
-            f"start={start_text} | end={end_text} | "
-            f"archive_at={archive_text} | archived_at={archived_text} | "
-            f"by=<@{campaign.created_by}>"
+            "https://discord.com/channels/"
+            f"{campaign.guild_id}/{campaign.channel_id}/{campaign.message_id}"
         )
+
+    @staticmethod
+    def _format_channel_reference(channel_id: int | None) -> str:
+        if channel_id is None:
+            return "-"
+        return f"<#{channel_id}>"
+
+    @staticmethod
+    def _truncate_embed_field_value(value: str, *, max_length: int = 1024) -> str:
+        if len(value) <= max_length:
+            return value
+        return f"{value[: max_length - 3]}..."
+
+    def _format_campaign_field_value(self, campaign: CTFRoleCampaign) -> str:
+        lines = [
+            f"状態: **{STATUS_LABELS.get(campaign.status, campaign.status.value)}**",
+            (
+                "開始: "
+                + self.usecase.format_unix_datetime_with_relative(
+                    campaign.start_at_unix
+                )
+            ),
+            (
+                "終了: "
+                + (
+                    self.usecase.format_unix_datetime_with_relative(
+                        campaign.end_at_unix
+                    )
+                    if campaign.end_at_unix is not None
+                    else "常設"
+                )
+            ),
+            (
+                "募集: "
+                f"[メッセージへ移動]({self._build_campaign_jump_url(campaign)}) "
+                f"({self._format_channel_reference(campaign.channel_id)})"
+            ),
+            f"議論: {self._format_channel_reference(campaign.discussion_channel_id)}",
+            f"VC: {self._format_channel_reference(campaign.voice_channel_id)}",
+            f"ロール: <@&{campaign.role_id}>",
+            f"作成者: <@{campaign.created_by}>",
+        ]
+        if campaign.archive_at_unix is not None:
+            lines.append(
+                "archive予定: "
+                + self.usecase.format_unix_datetime_with_relative(
+                    campaign.archive_at_unix
+                )
+            )
+        if campaign.archived_at_unix is not None:
+            lines.append(
+                "archive完了: "
+                + self.usecase.format_unix_datetime_with_relative(
+                    campaign.archived_at_unix
+                )
+            )
+        return self._truncate_embed_field_value("\n".join(lines))
+
+    def _build_campaign_list_embed(
+        self,
+        campaigns: builtins.list[CTFRoleCampaign],
+        *,
+        selected_status: str,
+    ) -> discord.Embed:
+        title_suffix = {
+            STATUS_ACTIVE: "募集中",
+            STATUS_CLOSED: "終了済み",
+            STATUS_ALL: "全件",
+        }.get(selected_status, selected_status)
+        color = {
+            STATUS_ACTIVE: discord.Color.green(),
+            STATUS_CLOSED: discord.Color.orange(),
+            STATUS_ALL: discord.Color.blurple(),
+        }.get(selected_status, discord.Color.blurple())
+        embed = discord.Embed(
+            title=f"CTF募集一覧 ({title_suffix})",
+            description=(
+                f"{len(campaigns)}件を表示しています。"
+                "時刻は各ユーザーのローカル時刻で表示されます。"
+            ),
+            color=color,
+        )
+        for index, campaign in enumerate(campaigns, start=1):
+            embed.add_field(
+                name=f"{index}. {campaign.ctf_name}",
+                value=self._format_campaign_field_value(campaign),
+                inline=False,
+            )
+        return embed
 
     async def _cleanup_created_resources(
         self,
@@ -828,7 +909,7 @@ class CTFRoleCampaigns(
         if message.content.startswith(CLOSED_HEADER):
             return True
 
-        archive_text = self.usecase.format_unix_datetime(archive_at_unix)
+        archive_text = self.usecase.format_unix_datetime_with_relative(archive_at_unix)
         try:
             await message.edit(
                 content=(
@@ -1025,12 +1106,11 @@ class CTFRoleCampaigns(
             )
             return
 
-        lines = [self._format_campaign_line(campaign) for campaign in campaigns]
-        content = "\n".join(lines)
-        if len(content) > 1900:
-            content = f"{content[:1897]}..."
-
-        await send_interaction_message(interaction, content, ephemeral=True)
+        embed = self._build_campaign_list_embed(
+            campaigns,
+            selected_status=selected_status,
+        )
+        await interaction.response.send_message(embed=embed, ephemeral=True)
 
     @app_commands.command(name="close", description="CTF募集を終了します。")
     @app_commands.describe(ctf_name="終了対象のCTF名")
@@ -1081,7 +1161,9 @@ class CTFRoleCampaigns(
             )
             return
 
-        archive_text = self.usecase.format_unix_datetime(report.archive_at_unix)
+        archive_text = self.usecase.format_unix_datetime_with_relative(
+            report.archive_at_unix
+        )
         member_count_text = (
             str(report.snapshot_member_count)
             if report.snapshot_member_count is not None

--- a/src/bot/features/ctf_roles/service.py
+++ b/src/bot/features/ctf_roles/service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 
 from ...errors import ServiceError
+from ...utils.helpers import format_discord_timestamp
 
 INPUT_DATETIME_FORMAT = "%Y-%m-%d %H:%M"
 
@@ -43,7 +44,12 @@ class CTFRoleService:
         utc = datetime.datetime.fromtimestamp(value, tz=datetime.UTC)
         return utc.astimezone(self._timezone)
 
-    def format_unix(self, value: int | None) -> str:
+    def format_unix(self, value: int | None, *, style: str = "f") -> str:
+        return format_discord_timestamp(value, style=style)
+
+    def format_unix_with_relative(self, value: int | None, *, style: str = "f") -> str:
         if value is None:
             return "-"
-        return self.from_unix(value).strftime("%Y-%m-%d %H:%M %Z")
+        absolute = self.format_unix(value, style=style)
+        relative = self.format_unix(value, style="R")
+        return f"{absolute} ({relative})"

--- a/src/bot/features/ctf_roles/usecase.py
+++ b/src/bot/features/ctf_roles/usecase.py
@@ -239,5 +239,13 @@ class CTFRoleUseCase:
             limit=limit,
         )
 
-    def format_unix_datetime(self, value: int | None) -> str:
-        return self._service.format_unix(value)
+    def format_unix_datetime(self, value: int | None, *, style: str = "f") -> str:
+        return self._service.format_unix(value, style=style)
+
+    def format_unix_datetime_with_relative(
+        self,
+        value: int | None,
+        *,
+        style: str = "f",
+    ) -> str:
+        return self._service.format_unix_with_relative(value, style=style)

--- a/src/bot/features/ctftime/cog.py
+++ b/src/bot/features/ctftime/cog.py
@@ -10,7 +10,12 @@ from discord.ext import commands, tasks
 from ...cogs._runtime import get_runtime
 from ...discord_gateway import DiscordGateway
 from ...errors import ExternalAPIError
-from ...utils.helpers import logger, send_interaction_message, send_message_safely
+from ...utils.helpers import (
+    format_discord_timestamp,
+    logger,
+    send_interaction_message,
+    send_message_safely,
+)
 from .models import CTFEvent
 
 
@@ -23,9 +28,6 @@ class CTFTimeNotifications(commands.Cog):
         self.settings = self.runtime.settings
         self.usecase = self.runtime.ctftime_usecase
         self.gateway = DiscordGateway(bot, logger)
-        self.timezone_label = getattr(
-            self.settings.tzinfo, "key", self.settings.timezone
-        )
         self.weekly_ctf_notification.change_interval(
             time=self.settings.ctftime_notification_time
         )
@@ -118,12 +120,14 @@ class CTFTimeNotifications(commands.Cog):
         )
 
         for index, event in enumerate(events[:25], start=1):
-            start_time = event.start.strftime("%m/%d %H:%M")
-            end_time = event.finish.strftime("%m/%d %H:%M")
+            start_time = format_discord_timestamp(event.start, style="f")
+            end_time = format_discord_timestamp(event.finish, style="f")
+            start_relative = format_discord_timestamp(event.start, style="R")
+            end_relative = format_discord_timestamp(event.finish, style="R")
             duration_hours = int((event.finish - event.start).total_seconds() / 3600)
             field_value = (
-                f"🕐 **開始**: {start_time} {self.timezone_label}\n"
-                f"🏁 **終了**: {end_time} {self.timezone_label}\n"
+                f"🕐 **開始**: {start_time} ({start_relative})\n"
+                f"🏁 **終了**: {end_time} ({end_relative})\n"
                 f"⏱️ **期間**: {duration_hours}時間\n"
                 f"🔗 [CTFtime]({event.ctftime_url})"
             )

--- a/src/bot/utils/helpers.py
+++ b/src/bot/utils/helpers.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 
 import discord
@@ -72,6 +73,26 @@ async def send_interaction_message(
         )
     except discord.HTTPException:
         logger.exception("Failed to send interaction response")
+
+
+def format_discord_timestamp(
+    value: int | float | datetime.datetime | None,
+    *,
+    style: str = "f",
+) -> str:
+    """Format a value as a Discord timestamp token."""
+    if value is None:
+        return "-"
+
+    if isinstance(value, datetime.datetime):
+        normalized = value
+        if normalized.tzinfo is None:
+            normalized = normalized.replace(tzinfo=datetime.UTC)
+        unix = int(normalized.astimezone(datetime.UTC).timestamp())
+    else:
+        unix = int(value)
+
+    return f"<t:{unix}:{style}>"
 
 
 def format_code_block(content: str, language: str = "") -> str:

--- a/tests/test_cogs.py
+++ b/tests/test_cogs.py
@@ -18,9 +18,14 @@ if str(SRC_ROOT) not in sys.path:
 
 from bot.config import Settings  # noqa: E402
 from bot.features.alpacahack.cog import Alpacahack  # noqa: E402
-from bot.features.alpacahack.models import SolvedChallenge  # noqa: E402
+from bot.features.alpacahack.models import (  # noqa: E402
+    SolvedChallenge,
+    UserMutationResult,
+    UserMutationStatus,
+)
 from bot.features.alpacahack.usecase import WeeklySolveSummary  # noqa: E402
 from bot.features.ctftime.cog import CTFTimeNotifications  # noqa: E402
+from bot.features.ctftime.models import CTFEvent  # noqa: E402
 from bot.runtime import build_runtime  # noqa: E402
 
 
@@ -195,6 +200,80 @@ class CogTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(embed.fields[-1].name, "取得失敗ユーザー")
         value = embed.fields[-1].value or ""
         self.assertIn("bob", value)
+        await fake_bot.close()
+
+    async def test_ctftime_embed_builder_uses_discord_timestamps(self):
+        runtime = self._build_runtime()
+        fake_bot = _FakeBot(runtime)
+        with patch("discord.ext.tasks.Loop.start", return_value=None):
+            cog = CTFTimeNotifications(fake_bot)
+
+        event = CTFEvent(
+            title="Example CTF",
+            start=datetime.datetime(2026, 3, 14, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
+            finish=datetime.datetime(2026, 3, 15, 9, 0, tzinfo=ZoneInfo("Asia/Tokyo")),
+            ctftime_url="https://ctftime.org/event/1",
+        )
+
+        embed = cog._build_events_embed([event])
+
+        self.assertEqual(len(embed.fields), 1)
+        value = embed.fields[0].value or ""
+        self.assertIn("<t:", value)
+        self.assertIn("(<t:", value)
+        self.assertNotIn("Asia/Tokyo", value)
+        await fake_bot.close()
+
+    async def test_alpacahack_add_replies_ephemerally_in_japanese(self):
+        runtime = self._build_runtime()
+        fake_bot = _FakeBot(runtime)
+        with patch("discord.ext.tasks.Loop.start", return_value=None):
+            cog = Alpacahack(fake_bot)
+
+        interaction = SimpleNamespace()
+        result = UserMutationResult(
+            status=UserMutationStatus.CREATED,
+            normalized_name="alice",
+        )
+        with (
+            patch.object(cog.usecase, "add_user", return_value=result),
+            patch(
+                "bot.features.alpacahack.cog.send_interaction_message",
+                new=AsyncMock(),
+            ) as send_mock,
+        ):
+            await Alpacahack.alpaca_add.callback(cog, interaction, "alice")
+
+        send_mock.assert_awaited_once_with(
+            interaction,
+            "`alice` を登録しました。",
+            ephemeral=True,
+        )
+        await fake_bot.close()
+
+    async def test_alpacahack_list_replies_ephemerally_with_header(self):
+        runtime = self._build_runtime()
+        fake_bot = _FakeBot(runtime)
+        with patch("discord.ext.tasks.Loop.start", return_value=None):
+            cog = Alpacahack(fake_bot)
+
+        interaction = SimpleNamespace()
+        with (
+            patch.object(cog.usecase, "list_usernames", return_value=["alice", "bob"]),
+            patch(
+                "bot.features.alpacahack.cog.send_interaction_message",
+                new=AsyncMock(),
+            ) as send_mock,
+        ):
+            await Alpacahack.alpaca_list.callback(cog, interaction)
+
+        await_args = send_mock.await_args
+        assert await_args is not None
+        self.assertEqual(await_args.args[0], interaction)
+        self.assertIn("登録済みAlpacaHackユーザー", await_args.args[1])
+        self.assertIn("- alice", await_args.args[1])
+        self.assertIn("- bob", await_args.args[1])
+        self.assertTrue(await_args.kwargs["ephemeral"])
         await fake_bot.close()
 
 

--- a/tests/test_ctf_roles.py
+++ b/tests/test_ctf_roles.py
@@ -3,6 +3,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 from zoneinfo import ZoneInfo
 
@@ -17,7 +18,11 @@ from bot.db.connection import DatabaseConnectionFactory  # noqa: E402
 from bot.db.migrations import apply_migrations  # noqa: E402
 from bot.errors import RepositoryError  # noqa: E402
 from bot.features.ctf_roles.cog import CTFRoleCampaigns  # noqa: E402
-from bot.features.ctf_roles.models import CampaignDraft, CampaignStatus  # noqa: E402
+from bot.features.ctf_roles.models import (  # noqa: E402
+    CampaignDraft,
+    CampaignStatus,
+    CTFRoleCampaign,
+)
 from bot.features.ctf_roles.repository import CTFRoleCampaignRepository  # noqa: E402
 from bot.features.ctf_roles.service import CTFRoleService  # noqa: E402
 from bot.features.ctf_roles.usecase import CTFRoleUseCase  # noqa: E402
@@ -360,6 +365,57 @@ class CTFRoleCogHelperTests(unittest.TestCase):
         self.assertIn(bot_member, overwrites)
         self.assertEqual(overwrites[bot_member].view_channel, True)
         self.assertEqual(overwrites[bot_member].send_messages, True)
+
+    def test_service_formats_discord_timestamp_with_relative(self) -> None:
+        service = CTFRoleService(timezone=ZoneInfo("Asia/Tokyo"))
+
+        formatted = service.format_unix_with_relative(1_700_000_000)
+
+        self.assertEqual(
+            formatted,
+            "<t:1700000000:f> (<t:1700000000:R>)",
+        )
+
+    def test_build_campaign_list_embed_contains_links_and_mentions(self) -> None:
+        cog = object.__new__(CTFRoleCampaigns)
+        cog.usecase = SimpleNamespace(
+            format_unix_datetime_with_relative=lambda value: (
+                f"<t:{value}:f> (<t:{value}:R>)"
+            )
+        )
+        campaign = CTFRoleCampaign(
+            id=1,
+            guild_id=10,
+            channel_id=100,
+            message_id=200,
+            role_id=300,
+            ctf_name="SECCON CTF",
+            start_at_unix=1_700_000_000,
+            end_at_unix=1_700_003_600,
+            status=CampaignStatus.ACTIVE,
+            created_by=400,
+            created_at_unix=1_699_999_000,
+            discussion_channel_id=500,
+            voice_channel_id=600,
+        )
+
+        embed = cog._build_campaign_list_embed([campaign], selected_status="active")
+
+        self.assertEqual(embed.title, "CTF募集一覧 (募集中)")
+        self.assertEqual(len(embed.fields), 1)
+        field = embed.fields[0]
+        self.assertEqual(field.name, "1. SECCON CTF")
+        self.assertIn("状態: **募集中**", field.value)
+        self.assertIn(
+            "[メッセージへ移動](https://discord.com/channels/10/100/200)",
+            field.value,
+        )
+        self.assertIn("(<#100>)", field.value)
+        self.assertIn("議論: <#500>", field.value)
+        self.assertIn("VC: <#600>", field.value)
+        self.assertIn("ロール: <@&300>", field.value)
+        self.assertIn("作成者: <@400>", field.value)
+        self.assertIn("<t:1700000000:f> (<t:1700000000:R>)", field.value)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 概要

  - Discord 上でのメッセージ確認をしやすくするため、`ctfteam` / `ctftime` / `alpaca` の user-facing な表示を改善

  ## 変更内容

  - `/ctfteam list` をテキスト一覧から embed 表示に変更
  - 募集メッセージへの jump link、discussion channel、VC、role、作成者を一覧から直接確認できるように変更
  - `ctf_roles` の募集作成・close・archive 関連の日時表示を Discord timestamp (`<t:...>`) ベースに変更
  - `ctftime` の予定 embed の開始/終了時刻を Discord timestamp 表示に変更
  - `alpaca add` / `alpaca del` / `alpaca list` の返信を日本語化し、`ephemeral` に変更
  - `alpaca list` の表示側の文字数前提を通常メッセージ向けに整理
  - 表示変更に合わせてテストを追加

## 確認内容

  - `uv run ruff format --check src tests`
  - `uv run ruff check src tests`
  - `uv run ty check`
  - `uv run python -m unittest discover -s tests -v`

## 補足

  - `/ctfteam list` の embed 全体文字数上限は、現時点では考慮不要という前提で対応