### PR TITLE
Feat/audit log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@
 | AlpacaHack 連携の仕様 | `docs/features/alpacahack.md` |
 | times チャンネルの仕様 | `docs/features/times.md` |
 | ユーティリティコマンドの仕様 | `docs/features/utility.md` |
+| 監査ログ保存の仕様 | `docs/features/audit-log.md` |
 | セットアップ・環境変数・Discord 設定 | `README.md` |
 
 ## アーキテクチャ制約

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ uv run python src/main.py
 - `Add Reactions`
 - `Manage Channels`
 - `Manage Roles`
+- `View Audit Log`
 
 `Manage Roles` を使うため、Bot のロールは操作対象のロールより上位に配置してください。
 

--- a/docs/features/audit-log.md
+++ b/docs/features/audit-log.md
@@ -1,0 +1,103 @@
+# 監査ログ保存 (audit_log)
+
+## 概要
+
+Discord サーバーの監査ログエントリを `on_audit_log_entry_create` イベントで受信し、SQLite に保存する。保存専用でコマンドは持たない。
+
+## 前提
+
+- Gateway intent: `moderation`（`Intents.default()` に含まれるため設定変更不要）
+- Guild 権限: bot のロールに `View Audit Log` が必要。権限がない場合、Discord はイベントを配信しないため何も保存されない（エラーにもならない）
+- README の「Bot に必要な権限」に `View Audit Log` を追記する
+
+## コマンド
+
+なし（保存専用）。参照コマンドは将来の別 PR で検討する。
+
+## イベント処理
+
+### `on_audit_log_entry_create(entry: discord.AuditLogEntry)`
+
+全 `AuditLogAction` を対象とし、フィルタしない。
+
+処理:
+1. `entry` から下記フィールドを抽出する
+2. `changes` は `{"before": dict(entry.changes.before), "after": dict(entry.changes.after)}` を `json.dumps(..., default=str, ensure_ascii=False)` で JSON 文字列化する（Discord オブジェクト等の非 JSON 値は `str()` に落ちる）
+3. `extra` は `entry.extra` が None でなければ `str(entry.extra)` を保存する
+4. DB 挿入は `asyncio.to_thread` 経由で行う
+5. `RepositoryError` は `logger.error` で記録し、raise しない（イベントループを止めない）
+
+| カラム | 取得元 |
+|---|---|
+| `entry_id` | `entry.id` |
+| `guild_id` | `entry.guild.id` |
+| `action` | `entry.action.name`（例: `channel_create`, `member_ban_add`） |
+| `user_id` | `entry.user_id`（実行者。system の場合 None） |
+| `target_id` | `getattr(entry.target, "id", None)` |
+| `reason` | `entry.reason` |
+| `changes_json` | 上記 2 の JSON 文字列 |
+| `extra_text` | 上記 3 の文字列 |
+| `created_at_unix` | `int(entry.created_at.timestamp())` |
+
+再接続時の重複配信に備え、`INSERT OR IGNORE` + `entry_id` の UNIQUE 制約で冪等にする。
+
+## データモデル
+
+dataclass は定義しない。保存専用で読み取りパスがないため、`Database` メソッドはキーワード引数を直接受け取る。
+
+```python
+def insert_audit_log_entry(
+    self,
+    *,
+    entry_id: int,
+    guild_id: int,
+    action: str,
+    user_id: int | None,
+    target_id: int | None,
+    reason: str | None,
+    changes_json: str,
+    extra_text: str | None,
+    created_at_unix: int,
+) -> bool:  # True: 挿入した / False: 重複でスキップ
+```
+
+## DB スキーマ
+
+`CURRENT_SCHEMA_VERSION` を 1 → 2 に上げ、`_MIGRATIONS[1]` に同じ DDL（`IF NOT EXISTS` 付き）を追加する。
+
+```sql
+CREATE TABLE IF NOT EXISTS audit_log_entry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_id INTEGER NOT NULL UNIQUE,
+    guild_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    user_id INTEGER,
+    target_id INTEGER,
+    reason TEXT,
+    changes_json TEXT NOT NULL,
+    extra_text TEXT,
+    created_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_guild_created
+    ON audit_log_entry (guild_id, created_at_unix);
+```
+
+## Embed / メッセージ形式
+
+なし（Discord への送信は行わない）。
+
+## 関連設定
+
+新規環境変数なし。
+
+## 関連変更
+
+- `utility.py` の `/perms` チェック項目に `Guild view_audit_log` を追加する（権限付与を bot 側から確認できるようにする）
+- `README.md` の「Bot に必要な権限」リストに `View Audit Log` を追加する
+
+## 対象外（今回実装しない）
+
+- 保存済みログの参照・検索コマンド
+- bot 起動前に発生したエントリのバックフィル（`guild.audit_logs()` での遡及取得）
+- 保持期間・自動削除

--- a/src/bot/cogs_loader.py
+++ b/src/bot/cogs_loader.py
@@ -6,6 +6,7 @@ DEFAULT_EXTENSIONS = (
     "bot.features.alpacahack",
     "bot.features.ctf_team.cog",
     "bot.features.ctftime",
+    "bot.features.audit_log",
 )
 
 

--- a/src/bot/db.py
+++ b/src/bot/db.py
@@ -6,8 +6,26 @@ from pathlib import Path
 from bot.errors import ConflictError, RepositoryError
 from bot.features.ctf_team.models import Campaign, CampaignStatus
 
-CURRENT_SCHEMA_VERSION = 1
-_MIGRATIONS: dict[int, str] = {}
+CURRENT_SCHEMA_VERSION = 2
+_MIGRATIONS: dict[int, str] = {
+    1: """\
+CREATE TABLE IF NOT EXISTS audit_log_entry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_id INTEGER NOT NULL UNIQUE,
+    guild_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    user_id INTEGER,
+    target_id INTEGER,
+    reason TEXT,
+    changes_json TEXT NOT NULL,
+    extra_text TEXT,
+    created_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_guild_created
+    ON audit_log_entry (guild_id, created_at_unix);
+""",
+}
 
 _SCHEMA_DDL = """\
 CREATE TABLE IF NOT EXISTS alpacahack_user (
@@ -45,6 +63,22 @@ CREATE INDEX IF NOT EXISTS idx_campaign_guild_status
 CREATE UNIQUE INDEX IF NOT EXISTS idx_campaign_active_name_unique
     ON ctf_team_campaign (guild_id, ctf_name)
     WHERE status = 'active';
+
+CREATE TABLE IF NOT EXISTS audit_log_entry (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    entry_id INTEGER NOT NULL UNIQUE,
+    guild_id INTEGER NOT NULL,
+    action TEXT NOT NULL,
+    user_id INTEGER,
+    target_id INTEGER,
+    reason TEXT,
+    changes_json TEXT NOT NULL,
+    extra_text TEXT,
+    created_at_unix INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_guild_created
+    ON audit_log_entry (guild_id, created_at_unix);
 """
 
 _CAMPAIGN_COLUMNS = (
@@ -154,6 +188,40 @@ class Database:
                 "SELECT name FROM alpacahack_user ORDER BY name ASC"
             ).fetchall()
         return [row[0] for row in rows]
+
+    def insert_audit_log_entry(
+        self,
+        *,
+        entry_id: int,
+        guild_id: int,
+        action: str,
+        user_id: int | None,
+        target_id: int | None,
+        reason: str | None,
+        changes_json: str,
+        extra_text: str | None,
+        created_at_unix: int,
+    ) -> bool:
+        with self._connection() as conn:
+            cur = conn.execute(
+                "INSERT OR IGNORE INTO audit_log_entry ("
+                "entry_id, guild_id, action, user_id, target_id, reason, "
+                "changes_json, extra_text, created_at_unix"
+                ") VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    entry_id,
+                    guild_id,
+                    action,
+                    user_id,
+                    target_id,
+                    reason,
+                    changes_json,
+                    extra_text,
+                    created_at_unix,
+                ),
+            )
+            conn.commit()
+            return cur.rowcount > 0
 
     def count_active_campaigns_by_creator(self, guild_id: int, created_by: int) -> int:
         with self._connection() as conn:

--- a/src/bot/features/audit_log.py
+++ b/src/bot/features/audit_log.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+
+import discord
+from discord.ext import commands
+
+from bot.errors import RepositoryError
+from bot.log import logger
+from bot.runtime import get_runtime
+
+
+class AuditLog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        runtime = get_runtime(bot)
+        self.bot = bot
+        self.settings = runtime.settings
+        self.db = runtime.db
+
+    @commands.Cog.listener()
+    async def on_audit_log_entry_create(self, entry: discord.AuditLogEntry) -> None:
+        changes_json = json.dumps(
+            {
+                "before": dict(entry.changes.before),
+                "after": dict(entry.changes.after),
+            },
+            default=str,
+            ensure_ascii=False,
+        )
+        try:
+            await asyncio.to_thread(
+                self.db.insert_audit_log_entry,
+                entry_id=entry.id,
+                guild_id=entry.guild.id,
+                action=entry.action.name,
+                user_id=entry.user_id,
+                target_id=getattr(entry.target, "id", None),
+                reason=entry.reason,
+                changes_json=changes_json,
+                extra_text=str(entry.extra) if entry.extra is not None else None,
+                created_at_unix=int(entry.created_at.timestamp()),
+            )
+        except RepositoryError as exc:
+            logger.error("Failed to save audit log entry %s: %s", entry.id, exc)
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(AuditLog(bot))

--- a/src/bot/features/utility.py
+++ b/src/bot/features/utility.py
@@ -47,6 +47,7 @@ class UtilityCommands(commands.Cog):
         guild_permissions = guild.me.guild_permissions
         channel_permissions = target.permissions_for(guild.me)
         checks = [
+            ("Guild view_audit_log", guild_permissions.view_audit_log),
             ("Guild manage_roles", guild_permissions.manage_roles),
             ("Channel view_channel", channel_permissions.view_channel),
             ("Channel send_messages", channel_permissions.send_messages),

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -56,6 +56,7 @@ class ArchitectureTest(unittest.TestCase):
             "bot.features.ctftime",
             "bot.features.times",
             "bot.features.utility",
+            "bot.features.audit_log",
             "bot.features.ctf_team",
         }
         for path in (SRC / "features").rglob("*.py"):

--- a/tests/test_audit_log.py
+++ b/tests/test_audit_log.py
@@ -1,0 +1,95 @@
+import datetime
+import json
+import unittest
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+import discord
+from discord.ext import commands
+
+from bot.errors import RepositoryError
+from bot.features.audit_log import AuditLog
+from bot.runtime import BotRuntime
+
+
+class StringValue:
+    def __str__(self) -> str:
+        return "string value"
+
+
+class AuditLogTest(unittest.IsolatedAsyncioTestCase):
+    def setUp(self) -> None:
+        self.db = mock.Mock()
+        bot = cast(
+            commands.Bot,
+            SimpleNamespace(runtime=BotRuntime(settings=mock.Mock(), db=self.db)),
+        )
+        self.cog = AuditLog(bot)
+
+    @staticmethod
+    def make_entry() -> discord.AuditLogEntry:
+        return cast(
+            discord.AuditLogEntry,
+            SimpleNamespace(
+                id=100,
+                guild=SimpleNamespace(id=200),
+                action=SimpleNamespace(name="member_ban_add"),
+                user_id=None,
+                target=SimpleNamespace(id=300),
+                reason="理由",
+                changes=SimpleNamespace(
+                    before={"name": "以前", "object": StringValue()},
+                    after={"name": "以後"},
+                ),
+                extra=StringValue(),
+                created_at=datetime.datetime(2026, 7, 6, tzinfo=datetime.UTC),
+            ),
+        )
+
+    async def test_event_serializes_and_inserts_entry(self) -> None:
+        entry = self.make_entry()
+        with mock.patch(
+            "bot.features.audit_log.asyncio.to_thread", new_callable=mock.AsyncMock
+        ) as to_thread:
+            await self.cog.on_audit_log_entry_create(entry)
+
+        to_thread.assert_awaited_once_with(
+            self.db.insert_audit_log_entry,
+            entry_id=100,
+            guild_id=200,
+            action="member_ban_add",
+            user_id=None,
+            target_id=300,
+            reason="理由",
+            changes_json=json.dumps(
+                {
+                    "before": {"name": "以前", "object": "string value"},
+                    "after": {"name": "以後"},
+                },
+                ensure_ascii=False,
+            ),
+            extra_text="string value",
+            created_at_unix=int(entry.created_at.timestamp()),
+        )
+
+    async def test_repository_error_is_logged_and_suppressed(self) -> None:
+        entry = self.make_entry()
+        error = RepositoryError("database unavailable")
+        with (
+            mock.patch(
+                "bot.features.audit_log.asyncio.to_thread",
+                new_callable=mock.AsyncMock,
+                side_effect=error,
+            ),
+            mock.patch("bot.features.audit_log.logger.error") as log_error,
+        ):
+            await self.cog.on_audit_log_entry_create(entry)
+
+        log_error.assert_called_once_with(
+            "Failed to save audit log entry %s: %s", entry.id, error
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -56,10 +56,12 @@ class DatabaseTest(unittest.TestCase):
             version = conn.execute("PRAGMA user_version").fetchone()[0]
         self.assertIn("alpacahack_user", tables)
         self.assertIn("ctf_team_campaign", tables)
+        self.assertIn("audit_log_entry", tables)
         self.assertIn("idx_campaign_guild_message", indexes)
         self.assertIn("idx_campaign_status_end", indexes)
         self.assertIn("idx_campaign_guild_status", indexes)
         self.assertIn("idx_campaign_active_name_unique", indexes)
+        self.assertIn("idx_audit_log_guild_created", indexes)
         self.assertEqual(version, CURRENT_SCHEMA_VERSION)
         Database(self.path)
 
@@ -83,9 +85,10 @@ class DatabaseTest(unittest.TestCase):
 
     def test_migration_applies_pending_scripts(self) -> None:
         migration = "ALTER TABLE alpacahack_user ADD COLUMN note TEXT"
+        next_version = CURRENT_SCHEMA_VERSION + 1
         with (
-            mock.patch("bot.db.CURRENT_SCHEMA_VERSION", 2),
-            mock.patch.dict("bot.db._MIGRATIONS", {1: migration}),
+            mock.patch("bot.db.CURRENT_SCHEMA_VERSION", next_version),
+            mock.patch.dict("bot.db._MIGRATIONS", {CURRENT_SCHEMA_VERSION: migration}),
         ):
             Database(self.path)
         with sqlite3.connect(self.path) as conn:
@@ -93,15 +96,38 @@ class DatabaseTest(unittest.TestCase):
             columns = {
                 row[1] for row in conn.execute("PRAGMA table_info(alpacahack_user)")
             }
-        self.assertEqual(version, 2)
+        self.assertEqual(version, next_version)
         self.assertIn("note", columns)
 
     def test_migration_missing_path_raises(self) -> None:
         with (
-            mock.patch("bot.db.CURRENT_SCHEMA_VERSION", 2),
+            mock.patch("bot.db.CURRENT_SCHEMA_VERSION", CURRENT_SCHEMA_VERSION + 1),
             self.assertRaises(RepositoryError),
         ):
             Database(self.path)
+
+    def test_migration_from_version_one_adds_audit_log_schema(self) -> None:
+        with sqlite3.connect(self.path) as conn:
+            conn.execute("DROP TABLE audit_log_entry")
+            conn.execute("PRAGMA user_version = 1")
+        Database(self.path)
+        with sqlite3.connect(self.path) as conn:
+            tables = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'"
+                )
+            }
+            indexes = {
+                row[0]
+                for row in conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='index'"
+                )
+            }
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+        self.assertIn("audit_log_entry", tables)
+        self.assertIn("idx_audit_log_guild_created", indexes)
+        self.assertEqual(version, CURRENT_SCHEMA_VERSION)
 
     def test_alpacahack_users(self) -> None:
         self.assertTrue(self.db.add_alpacahack_user(" zeta "))
@@ -110,6 +136,27 @@ class DatabaseTest(unittest.TestCase):
         self.assertEqual(self.db.list_alpacahack_users(), ["alpha", "zeta"])
         self.assertTrue(self.db.delete_alpacahack_user("alpha"))
         self.assertFalse(self.db.delete_alpacahack_user("missing"))
+
+    def test_insert_audit_log_entry_is_idempotent(self) -> None:
+        values = {
+            "entry_id": 10,
+            "guild_id": 20,
+            "action": "channel_create",
+            "user_id": 30,
+            "target_id": 40,
+            "reason": "test reason",
+            "changes_json": '{"before": {}, "after": {}}',
+            "extra_text": "extra",
+            "created_at_unix": 50,
+        }
+        self.assertTrue(self.db.insert_audit_log_entry(**values))
+        self.assertFalse(self.db.insert_audit_log_entry(**values))
+        with sqlite3.connect(self.path) as conn:
+            row = conn.execute(
+                "SELECT entry_id, guild_id, action, user_id, target_id, reason, "
+                "changes_json, extra_text, created_at_unix FROM audit_log_entry"
+            ).fetchone()
+        self.assertEqual(row, tuple(values.values()))
 
     def test_create_and_find_campaign(self) -> None:
         created = self.create_campaign()


### PR DESCRIPTION
  ## 概要

  Discord サーバーの監査ログエントリを `on_audit_log_entry_create` で受信し、SQLite
  に保存する機能を追加します。

  設計仕様: `docs/features/audit-log.md`

  ## 変更内容

  - 新 cog `bot.features.audit_log`（保存専用・コマンドなし）
  - DB スキーマ v1 → v2: `audit_log_entry` テーブル追加（`entry_id` UNIQUE + `INSERT OR
  IGNORE` で冪等）
  - `/perms` に `Guild view_audit_log` チェックを追加
  - README の必要権限に `View Audit Log` を追記

  ## デプロイ前の依頼事項

  ⚠️ bot のロールに **View Audit Log（監査ログを表示）**
  権限の付与が必要です（サーバー管理者に依頼）。
  権限がなくてもエラーにはならず、イベントが配信されないため保存されないだけです。付与後は
  `/perms` で確認できます。

  ## 検証

  - `ruff check` / `ruff format --check` ✅
  - `ty check` ✅
  - `unittest` 64 件すべてパス ✅
